### PR TITLE
Fix(LOCAT-BE-46): 인증 체인 동작 보완 및 수정

### DIFF
--- a/src/main/java/com/locat/api/domain/user/entity/User.java
+++ b/src/main/java/com/locat/api/domain/user/entity/User.java
@@ -39,7 +39,6 @@ public class User extends SecuredBaseEntity {
   private Long id;
 
   @Column(name = "oauth_id", nullable = false, length = 100)
-  @Convert(converter = StringColumnEncryptionConverter.class)
   private String oauthId;
 
   @Enumerated(EnumType.STRING)

--- a/src/main/java/com/locat/api/domain/user/service/UserService.java
+++ b/src/main/java/com/locat/api/domain/user/service/UserService.java
@@ -9,7 +9,5 @@ public interface UserService {
 
   User findById(final Long id);
 
-  Optional<User> findByEmail(final String email);
-
   Optional<User> findByOauthId(final String oauthId);
 }

--- a/src/main/java/com/locat/api/domain/user/service/impl/UserServiceImpl.java
+++ b/src/main/java/com/locat/api/domain/user/service/impl/UserServiceImpl.java
@@ -31,12 +31,6 @@ public class UserServiceImpl implements UserService {
   }
 
   @Override
-  @Transactional(readOnly = true)
-  public Optional<User> findByEmail(String email) {
-    return this.userRepository.findByEmail(email);
-  }
-
-  @Override
   public Optional<User> findByOauthId(String oauthId) {
     return this.userRepository.findByOauthId(oauthId);
   }

--- a/src/main/java/com/locat/api/global/auth/LocatUserDetailsService.java
+++ b/src/main/java/com/locat/api/global/auth/LocatUserDetailsService.java
@@ -1,11 +1,25 @@
 package com.locat.api.global.auth;
 
+import com.locat.api.global.exception.NoSuchEntityException;
 import org.springframework.security.core.Authentication;
 import org.springframework.security.core.userdetails.UserDetailsService;
 
 public interface LocatUserDetailsService extends UserDetailsService {
 
-  Authentication createAuthentication(String username);
+  /**
+   * 사용자 ID로 인증 객체 {@link Authentication}을 생성합니다.
+   *
+   * @param userId 사용자 ID
+   * @return 인증 객체 {@link Authentication}
+   * @throws NoSuchEntityException 해당 ID를 가지는 사용자가 없을 경우
+   */
+  Authentication createAuthentication(String userId);
 
+  /**
+   * 인증 객체로부터 권한 정보를 추출합니다.
+   *
+   * @param authentication 인증 객체
+   * @return 권한 정보
+   */
   String extractAuthorities(Authentication authentication);
 }

--- a/src/main/java/com/locat/api/global/auth/impl/LocatUserDetailsImpl.java
+++ b/src/main/java/com/locat/api/global/auth/impl/LocatUserDetailsImpl.java
@@ -41,7 +41,7 @@ public record LocatUserDetailsImpl(User user)
 
   @Override
   public String getUsername() {
-    return this.user.getEmail();
+    return this.user.getId().toString();
   }
 
   @Override

--- a/src/main/java/com/locat/api/global/auth/impl/LocatUserDetailsServiceImpl.java
+++ b/src/main/java/com/locat/api/global/auth/impl/LocatUserDetailsServiceImpl.java
@@ -2,8 +2,6 @@ package com.locat.api.global.auth.impl;
 
 import com.locat.api.domain.user.service.UserService;
 import com.locat.api.global.auth.LocatUserDetailsService;
-import com.locat.api.global.exception.ApiExceptionType;
-import com.locat.api.global.exception.NoSuchEntityException;
 import java.util.stream.Collectors;
 import lombok.RequiredArgsConstructor;
 import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
@@ -19,16 +17,13 @@ public class LocatUserDetailsServiceImpl implements LocatUserDetailsService {
   private final UserService userService;
 
   @Override
-  public UserDetails loadUserByUsername(String username) {
-    return this.userService
-        .findByEmail(username)
-        .map(LocatUserDetailsImpl::from)
-        .orElseThrow(() -> new NoSuchEntityException(ApiExceptionType.NOT_FOUND_USER));
+  public UserDetails loadUserByUsername(String userId) {
+    return LocatUserDetailsImpl.from(this.userService.findById(Long.parseLong(userId)));
   }
 
   @Override
-  public Authentication createAuthentication(String username) {
-    UserDetails userDetails = this.loadUserByUsername(username);
+  public Authentication createAuthentication(String userId) {
+    UserDetails userDetails = this.loadUserByUsername(userId);
     return new UsernamePasswordAuthenticationToken(userDetails, null, userDetails.getAuthorities());
   }
 

--- a/src/main/java/com/locat/api/global/auth/jwt/JwtProvider.java
+++ b/src/main/java/com/locat/api/global/auth/jwt/JwtProvider.java
@@ -9,10 +9,10 @@ public interface JwtProvider {
   /**
    * 토큰 생성
    *
-   * @param userEmail 사용자 이메일
+   * @param userId 사용자 ID
    * @return 토큰 발급 응답 DTO
    */
-  LocatTokenDto create(String userEmail);
+  LocatTokenDto create(Long userId);
 
   LocatTokenDto renew(String oldAccessToken, String refreshToken);
 

--- a/src/main/java/com/locat/api/global/auth/jwt/JwtProviderImpl.java
+++ b/src/main/java/com/locat/api/global/auth/jwt/JwtProviderImpl.java
@@ -57,10 +57,11 @@ public class JwtProviderImpl implements JwtProvider {
   }
 
   @Override
-  public LocatTokenDto create(String userEmail) {
+  public LocatTokenDto create(final Long userId) {
+    final String userIdStr = userId.toString();
     LocatUserDetails userDetails =
-        (LocatUserDetails) this.userDetailsService.loadUserByUsername(userEmail);
-    Authentication authentication = this.userDetailsService.createAuthentication(userEmail);
+        (LocatUserDetails) this.userDetailsService.loadUserByUsername(userIdStr);
+    Authentication authentication = this.userDetailsService.createAuthentication(userIdStr);
 
     String accessToken = this.createAccessToken(authentication);
     String refreshToken = this.createRefreshToken(authentication.getName());

--- a/src/main/java/com/locat/api/global/security/LocatAccessDeniedHandler.java
+++ b/src/main/java/com/locat/api/global/security/LocatAccessDeniedHandler.java
@@ -6,10 +6,12 @@ import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
 import java.io.IOException;
 import java.io.PrintWriter;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.MediaType;
 import org.springframework.security.access.AccessDeniedException;
 import org.springframework.security.web.access.AccessDeniedHandler;
 
+@Slf4j
 public class LocatAccessDeniedHandler implements AccessDeniedHandler {
 
   @Override
@@ -18,13 +20,16 @@ public class LocatAccessDeniedHandler implements AccessDeniedHandler {
       HttpServletResponse response,
       AccessDeniedException accessDeniedException)
       throws IOException, ServletException {
-    PrintWriter out = response.getWriter();
+    if (log.isDebugEnabled()) {
+      log.debug("Access Denied: {}", accessDeniedException.getMessage());
+    }
 
     response.setContentType(MediaType.APPLICATION_JSON_VALUE);
     response.setStatus(HttpServletResponse.SC_FORBIDDEN);
 
-    out.print(ErrorResponse.forbidden());
-    out.flush();
-    out.close();
+    try (PrintWriter out = response.getWriter()) {
+      out.print(ErrorResponse.forbidden());
+      out.flush();
+    }
   }
 }

--- a/src/main/java/com/locat/api/global/security/LocatAuditorAware.java
+++ b/src/main/java/com/locat/api/global/security/LocatAuditorAware.java
@@ -4,12 +4,15 @@ import com.locat.api.global.auth.LocatUserDetails;
 import java.util.Optional;
 import org.springframework.data.domain.AuditorAware;
 import org.springframework.security.core.Authentication;
+import org.springframework.security.core.context.SecurityContext;
 import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.stereotype.Component;
 
 /** Auditing을 위한 현재 사용자 정보를 제공하는 클래스입니다.<br> */
 @Component
 public class LocatAuditorAware implements AuditorAware<Long> {
+
+  public static final String PRINCIPAL_ANONYMOUS_USER = "anonymousUser";
 
   /**
    * Spring Security의 {@link SecurityContextHolder}를 사용하여 현재 사용자 정보를 가져옵니다. <br>
@@ -20,10 +23,16 @@ public class LocatAuditorAware implements AuditorAware<Long> {
    */
   @Override
   public Optional<Long> getCurrentAuditor() {
-    return Optional.ofNullable(SecurityContextHolder.getContext().getAuthentication())
+    return Optional.of(SecurityContextHolder.getContext())
+        .map(SecurityContext::getAuthentication)
         .filter(Authentication::isAuthenticated)
+        .filter(this::isNotAnonymous)
         .map(Authentication::getPrincipal)
         .map(LocatUserDetails.class::cast)
         .map(LocatUserDetails::getId);
+  }
+
+  private boolean isNotAnonymous(Authentication authentication) {
+    return !PRINCIPAL_ANONYMOUS_USER.equalsIgnoreCase(authentication.getName());
   }
 }

--- a/src/main/java/com/locat/api/global/security/LocatAuthEntryPoint.java
+++ b/src/main/java/com/locat/api/global/security/LocatAuthEntryPoint.java
@@ -5,10 +5,12 @@ import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
 import java.io.IOException;
 import java.io.PrintWriter;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.MediaType;
 import org.springframework.security.core.AuthenticationException;
 import org.springframework.security.web.AuthenticationEntryPoint;
 
+@Slf4j
 public class LocatAuthEntryPoint implements AuthenticationEntryPoint {
 
   @Override
@@ -17,13 +19,16 @@ public class LocatAuthEntryPoint implements AuthenticationEntryPoint {
       HttpServletResponse response,
       AuthenticationException authException)
       throws IOException {
-    PrintWriter out = response.getWriter();
+    if (log.isDebugEnabled()) {
+      log.debug("UnAuthorized: {}", authException.getMessage());
+    }
 
     response.setContentType(MediaType.APPLICATION_JSON_VALUE);
     response.setStatus(HttpServletResponse.SC_UNAUTHORIZED);
 
-    out.print(ErrorResponse.unauthorized());
-    out.flush();
-    out.close();
+    try (PrintWriter out = response.getWriter()) {
+      out.print(ErrorResponse.unauthorized());
+      out.flush();
+    }
   }
 }

--- a/src/main/java/com/locat/api/global/security/StringColumnEncryptionConverter.java
+++ b/src/main/java/com/locat/api/global/security/StringColumnEncryptionConverter.java
@@ -21,8 +21,8 @@ public class StringColumnEncryptionConverter implements AttributeConverter<Strin
   /** 암호화 알고리즘: AES/GCM/NoPadding */
   private static final String ENCRYPTION_TRANSFORM = "AES/GCM/NoPadding";
 
-  /** AES 키의 길이: 16 바이트 */
-  private static final int AES_KEY_LENGTH = 16;
+  /** AES 키의 길이: 32 바이트 */
+  private static final int AES_KEY_LENGTH = 32;
 
   /** 초기화 벡터의 길이: 12 바이트로 고정 */
   private static final int INITIAL_VECTOR_LENGTH = 12;

--- a/src/test/java/com/locat/api/unit/security/StringColumnEncryptionConverterTest.java
+++ b/src/test/java/com/locat/api/unit/security/StringColumnEncryptionConverterTest.java
@@ -19,7 +19,8 @@ class StringColumnEncryptionConverterTest {
 
   @BeforeEach
   void setUp() {
-    ReflectionTestUtils.setField(this.converter, "encryptionKey", "testEncryptionKey123", String.class);
+    ReflectionTestUtils.setField(
+        this.converter, "encryptionKey", "testEncryptionKey123", String.class);
     MockitoAnnotations.openMocks(this);
     this.converter.init();
   }
@@ -64,5 +65,4 @@ class StringColumnEncryptionConverterTest {
     assertThat(encrypted).isNull();
     assertThat(decrypted).isNull();
   }
-
 }


### PR DESCRIPTION
- 토큰 Subject, Authentication 이름 등이 ID를 가지도록 수정
- AuditorAware가 UserDetail 캐스팅 전에 익명 사용자인지까지 체크하도록 수정
- 암호화 AES-256으로 개선

## **해결하려는 문제가 무엇인가요?**

- `LocatAuditorAware`에서 익명 사용자인 경우에도 `isAuthenticated == true`로 처리되는데 이는 의도한 동작이 아니므로 수정 필요
- `StringColumnEncryptionConverter`로 암호화되는 값의 경우, 같은 평문이어도 다른 값으로 암호화되기 때문에 `findBy` 등 쿼리 활용 불가한 이슈

## **어떻게 해결했나요?**

- 익명 사용자인 경우 principal: "anonymousUser"로 구분되므로 해당 값에 대한 필터링 추가
- 인증 체인, 토큰 발급 등에서 username(email)을 사용하는 부분을 사용자 고유 식별자(ID)를 사용하도록 수정

## **어떤 부분에 집중하여 리뷰해야 할까요?**

- 인증 체인과 관련 로직 내에서 사용자 구분값이 username(email) → userId로 바뀌지 않은 부분이 있는지 체크해주세요
(override한 메서드라 시그니처 변경이 안되므로 loadUserByUsername는 제외해주세요! )

## **참고 자료**

- 참고할 만한 자료나 문서를 첨부해주세요. _(관련 스펙, 문서, 혹은 참고한 자료 등)_
- (실제로 작성하실 때, 위의 설명, 예시는 지우고 작성해주세요!)

## **체크리스트**
- [ ] 모든 commit이 push 되었나요?
- [x] merge할 branch를 확인했나요?
- [x] API 문서를 업데이트 & 문법 검사를 진행했나요?

[//]: # (- [ ] 테스트가 전부 통과되었나요?)
