### PR TITLE
Feat(LOCAT-BE-50): User Domain 추상화 및 관리자 Entity 추가

### DIFF
--- a/src/main/java/com/locat/api/domain/admin/controller/AdminController.java
+++ b/src/main/java/com/locat/api/domain/admin/controller/AdminController.java
@@ -1,0 +1,30 @@
+package com.locat.api.domain.admin.controller;
+
+import com.locat.api.domain.admin.dto.AdminPasswordResetRequest;
+import com.locat.api.domain.admin.service.AdminInternalService;
+import com.locat.api.domain.common.dto.BaseResponse;
+import com.locat.api.global.auth.LocatUserDetails;
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/v1/admin")
+public class AdminController {
+
+  private final AdminInternalService adminInternalService;
+
+  @PostMapping("/reset-password")
+  public ResponseEntity<BaseResponse<Void>> resetPassword(
+      @AuthenticationPrincipal LocatUserDetails userDetails,
+      @RequestBody @Valid final AdminPasswordResetRequest request) {
+    this.adminInternalService.resetPassword(userDetails.getId(), request.newPassword());
+    return ResponseEntity.ok(BaseResponse.ofEmpty());
+  }
+}

--- a/src/main/java/com/locat/api/domain/admin/dto/AdminPasswordResetRequest.java
+++ b/src/main/java/com/locat/api/domain/admin/dto/AdminPasswordResetRequest.java
@@ -1,0 +1,5 @@
+package com.locat.api.domain.admin.dto;
+
+import jakarta.validation.constraints.NotEmpty;
+
+public record AdminPasswordResetRequest(@NotEmpty String newPassword) {}

--- a/src/main/java/com/locat/api/domain/admin/service/AdminInternalService.java
+++ b/src/main/java/com/locat/api/domain/admin/service/AdminInternalService.java
@@ -1,0 +1,6 @@
+package com.locat.api.domain.admin.service;
+
+public interface AdminInternalService {
+
+  void resetPassword(final Long userId, final String newPassword);
+}

--- a/src/main/java/com/locat/api/domain/admin/service/impl/AdminInternalServiceImpl.java
+++ b/src/main/java/com/locat/api/domain/admin/service/impl/AdminInternalServiceImpl.java
@@ -1,0 +1,32 @@
+package com.locat.api.domain.admin.service.impl;
+
+import com.locat.api.domain.admin.service.AdminInternalService;
+import com.locat.api.domain.user.entity.User;
+import com.locat.api.domain.user.service.UserService;
+import com.locat.api.global.exception.ApiExceptionType;
+import com.locat.api.global.exception.NoSuchEntityException;
+import lombok.RequiredArgsConstructor;
+import org.springframework.security.crypto.password.PasswordEncoder;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@Transactional
+@RequiredArgsConstructor
+public class AdminInternalServiceImpl implements AdminInternalService {
+
+  private final UserService userService;
+  private final PasswordEncoder passwordEncoder;
+
+  @Override
+  public void resetPassword(Long userId, String newPassword) {
+    this.userService
+        .findById(userId)
+        .map(User::asAdmin)
+        .ifPresentOrElse(
+            adminUser -> adminUser.resetPassword(this.passwordEncoder.encode(newPassword)),
+            () -> {
+              throw new NoSuchEntityException(ApiExceptionType.NOT_FOUND_USER);
+            });
+  }
+}

--- a/src/main/java/com/locat/api/domain/auth/controller/AuthController.java
+++ b/src/main/java/com/locat/api/domain/auth/controller/AuthController.java
@@ -1,8 +1,11 @@
 package com.locat.api.domain.auth.controller;
 
+import com.locat.api.domain.auth.dto.AdminLoginDto;
+import com.locat.api.domain.auth.dto.request.AdminLoginRequest;
 import com.locat.api.domain.auth.dto.request.EmailVerificationRequest;
 import com.locat.api.domain.auth.dto.request.TokenIssueRequest;
 import com.locat.api.domain.auth.dto.request.TokenRenewRequest;
+import com.locat.api.domain.auth.dto.response.AdminLoginResponse;
 import com.locat.api.domain.auth.service.AuthService;
 import com.locat.api.domain.common.dto.BaseResponse;
 import com.locat.api.global.auth.jwt.LocatTokenDto;
@@ -26,6 +29,14 @@ public class AuthController {
       @RequestBody @Valid final TokenIssueRequest request) {
     LocatTokenDto locatTokenDto = this.authService.authenticate(request.oAuthId());
     return ResponseEntity.ok((BaseResponse.of(locatTokenDto)));
+  }
+
+  @PostMapping("/admin/token")
+  public ResponseEntity<BaseResponse<AdminLoginResponse>> authenticateAdmin(
+      @RequestBody @Valid final AdminLoginRequest request) {
+    AdminLoginResponse adminLoginResponse =
+        this.authService.authenticate(AdminLoginDto.fromRequest(request));
+    return ResponseEntity.ok((BaseResponse.of(adminLoginResponse)));
   }
 
   @PostMapping("/renew")

--- a/src/main/java/com/locat/api/domain/auth/controller/OAuthRedirectDispatcher.java
+++ b/src/main/java/com/locat/api/domain/auth/controller/OAuthRedirectDispatcher.java
@@ -2,7 +2,7 @@ package com.locat.api.domain.auth.controller;
 
 import com.locat.api.domain.auth.service.OAuth2Service;
 import com.locat.api.domain.common.dto.BaseResponse;
-import com.locat.api.domain.user.entity.OAuth2ProviderType;
+import com.locat.api.domain.user.enums.OAuth2ProviderType;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;

--- a/src/main/java/com/locat/api/domain/auth/dto/AdminLoginDto.java
+++ b/src/main/java/com/locat/api/domain/auth/dto/AdminLoginDto.java
@@ -1,0 +1,10 @@
+package com.locat.api.domain.auth.dto;
+
+import com.locat.api.domain.auth.dto.request.AdminLoginRequest;
+
+public record AdminLoginDto(String deviceId, String userId, String password) {
+
+  public static AdminLoginDto fromRequest(AdminLoginRequest request) {
+    return new AdminLoginDto(request.deviceId(), request.userId(), request.password());
+  }
+}

--- a/src/main/java/com/locat/api/domain/auth/dto/AppleIdToken.java
+++ b/src/main/java/com/locat/api/domain/auth/dto/AppleIdToken.java
@@ -2,7 +2,7 @@ package com.locat.api.domain.auth.dto;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.locat.api.domain.user.dto.OAuth2UserInfoDto;
-import com.locat.api.domain.user.entity.OAuth2ProviderType;
+import com.locat.api.domain.user.enums.OAuth2ProviderType;
 import io.jsonwebtoken.Claims;
 import lombok.Builder;
 

--- a/src/main/java/com/locat/api/domain/auth/dto/request/AdminLoginRequest.java
+++ b/src/main/java/com/locat/api/domain/auth/dto/request/AdminLoginRequest.java
@@ -1,0 +1,7 @@
+package com.locat.api.domain.auth.dto.request;
+
+import jakarta.validation.constraints.Email;
+import jakarta.validation.constraints.NotEmpty;
+
+public record AdminLoginRequest(
+    @NotEmpty String deviceId, @Email String userId, @NotEmpty String password) {}

--- a/src/main/java/com/locat/api/domain/auth/dto/request/OAuth2AuthorizeRequest.java
+++ b/src/main/java/com/locat/api/domain/auth/dto/request/OAuth2AuthorizeRequest.java
@@ -1,6 +1,6 @@
 package com.locat.api.domain.auth.dto.request;
 
-import com.locat.api.domain.user.entity.OAuth2ProviderType;
+import com.locat.api.domain.user.enums.OAuth2ProviderType;
 
 /**
  * OAuth2 인증 요청 DTO

--- a/src/main/java/com/locat/api/domain/auth/dto/response/AdminLoginResponse.java
+++ b/src/main/java/com/locat/api/domain/auth/dto/response/AdminLoginResponse.java
@@ -1,0 +1,11 @@
+package com.locat.api.domain.auth.dto.response;
+
+import com.locat.api.global.auth.jwt.LocatTokenDto;
+
+public record AdminLoginResponse(Boolean isPasswordExpired, Boolean needMfa, LocatTokenDto token) {
+
+  public static AdminLoginResponse of(
+      Boolean isPasswordExpired, Boolean needMfa, LocatTokenDto token) {
+    return new AdminLoginResponse(isPasswordExpired, needMfa, token);
+  }
+}

--- a/src/main/java/com/locat/api/domain/auth/entity/LocatRefreshToken.java
+++ b/src/main/java/com/locat/api/domain/auth/entity/LocatRefreshToken.java
@@ -14,14 +14,20 @@ public class LocatRefreshToken {
 
   @Id private Long id;
 
+  private String email;
+
   private String refreshToken;
 
   @TimeToLive private Long refreshTokenExpiresIn;
 
   public static LocatRefreshToken from(
-      final Long id, final String refreshToken, final Duration refreshTokenExpiresIn) {
+      final Long id,
+      final String email,
+      final String refreshToken,
+      final Duration refreshTokenExpiresIn) {
     return LocatRefreshToken.builder()
         .id(id)
+        .email(email)
         .refreshToken(refreshToken)
         .refreshTokenExpiresIn(refreshTokenExpiresIn.toSeconds())
         .build();

--- a/src/main/java/com/locat/api/domain/auth/entity/OAuth2ProviderToken.java
+++ b/src/main/java/com/locat/api/domain/auth/entity/OAuth2ProviderToken.java
@@ -1,7 +1,7 @@
 package com.locat.api.domain.auth.entity;
 
 import com.locat.api.domain.auth.dto.OAuth2ProviderTokenDto;
-import com.locat.api.domain.user.entity.OAuth2ProviderType;
+import com.locat.api.domain.user.enums.OAuth2ProviderType;
 import jakarta.persistence.Id;
 import lombok.Builder;
 import lombok.Getter;

--- a/src/main/java/com/locat/api/domain/auth/service/AuthService.java
+++ b/src/main/java/com/locat/api/domain/auth/service/AuthService.java
@@ -1,10 +1,14 @@
 package com.locat.api.domain.auth.service;
 
+import com.locat.api.domain.auth.dto.AdminLoginDto;
+import com.locat.api.domain.auth.dto.response.AdminLoginResponse;
 import com.locat.api.global.auth.jwt.LocatTokenDto;
 
 public interface AuthService {
 
   LocatTokenDto authenticate(String oAuthId);
+
+  AdminLoginResponse authenticate(AdminLoginDto loginDto);
 
   LocatTokenDto renew(String accessToken, String refreshToken);
 

--- a/src/main/java/com/locat/api/domain/auth/service/OAuth2Service.java
+++ b/src/main/java/com/locat/api/domain/auth/service/OAuth2Service.java
@@ -1,6 +1,6 @@
 package com.locat.api.domain.auth.service;
 
-import com.locat.api.domain.user.entity.OAuth2ProviderType;
+import com.locat.api.domain.user.enums.OAuth2ProviderType;
 
 public interface OAuth2Service {
 

--- a/src/main/java/com/locat/api/domain/auth/service/impl/OAuth2ServiceImpl.java
+++ b/src/main/java/com/locat/api/domain/auth/service/impl/OAuth2ServiceImpl.java
@@ -3,7 +3,7 @@ package com.locat.api.domain.auth.service.impl;
 import com.locat.api.domain.auth.service.OAuth2Service;
 import com.locat.api.domain.auth.template.OAuth2Template;
 import com.locat.api.domain.auth.template.OAuth2TemplateFactory;
-import com.locat.api.domain.user.entity.OAuth2ProviderType;
+import com.locat.api.domain.user.enums.OAuth2ProviderType;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 

--- a/src/main/java/com/locat/api/domain/auth/template/OAuth2TemplateFactory.java
+++ b/src/main/java/com/locat/api/domain/auth/template/OAuth2TemplateFactory.java
@@ -1,6 +1,6 @@
 package com.locat.api.domain.auth.template;
 
-import com.locat.api.domain.user.entity.OAuth2ProviderType;
+import com.locat.api.domain.user.enums.OAuth2ProviderType;
 
 public interface OAuth2TemplateFactory {
 

--- a/src/main/java/com/locat/api/domain/auth/template/OAuth2TemplateFactoryImpl.java
+++ b/src/main/java/com/locat/api/domain/auth/template/OAuth2TemplateFactoryImpl.java
@@ -3,7 +3,7 @@ package com.locat.api.domain.auth.template;
 import com.locat.api.domain.auth.entity.OAuth2ProviderToken;
 import com.locat.api.domain.auth.template.impl.AppleOAuth2Template;
 import com.locat.api.domain.auth.template.impl.KakaoOAuth2Template;
-import com.locat.api.domain.user.entity.OAuth2ProviderType;
+import com.locat.api.domain.user.enums.OAuth2ProviderType;
 import com.locat.api.global.auth.AuthenticationException;
 import com.locat.api.global.exception.ApiExceptionType;
 import com.locat.api.infrastructure.redis.OAuth2ProviderTokenRepository;

--- a/src/main/java/com/locat/api/domain/auth/template/impl/AppleOAuth2Template.java
+++ b/src/main/java/com/locat/api/domain/auth/template/impl/AppleOAuth2Template.java
@@ -8,7 +8,7 @@ import com.locat.api.domain.auth.template.OAuth2Properties;
 import com.locat.api.domain.auth.utils.AppleClientSecretProvider;
 import com.locat.api.domain.auth.utils.OpenIDConnectTokenUtils;
 import com.locat.api.domain.user.dto.OAuth2UserInfoDto;
-import com.locat.api.domain.user.entity.OAuth2ProviderType;
+import com.locat.api.domain.user.enums.OAuth2ProviderType;
 import com.locat.api.global.exception.InternalProcessingException;
 import com.locat.api.infrastructure.external.AppleOAuth2Client;
 import com.locat.api.infrastructure.redis.OAuth2ProviderTokenRepository;

--- a/src/main/java/com/locat/api/domain/auth/template/impl/KakaoOAuth2Template.java
+++ b/src/main/java/com/locat/api/domain/auth/template/impl/KakaoOAuth2Template.java
@@ -5,7 +5,7 @@ import com.locat.api.domain.auth.entity.OAuth2ProviderToken;
 import com.locat.api.domain.auth.template.AbstractOAuth2Template;
 import com.locat.api.domain.auth.template.OAuth2Properties;
 import com.locat.api.domain.user.dto.OAuth2UserInfoDto;
-import com.locat.api.domain.user.entity.OAuth2ProviderType;
+import com.locat.api.domain.user.enums.OAuth2ProviderType;
 import com.locat.api.infrastructure.external.KakaoOAuth2Client;
 import com.locat.api.infrastructure.external.KakaoUserClient;
 import com.locat.api.infrastructure.redis.OAuth2ProviderTokenRepository;

--- a/src/main/java/com/locat/api/domain/geo/base/entity/GeoItem.java
+++ b/src/main/java/com/locat/api/domain/geo/base/entity/GeoItem.java
@@ -3,7 +3,7 @@ package com.locat.api.domain.geo.base.entity;
 import com.locat.api.domain.common.entity.SecuredBaseEntity;
 import com.locat.api.domain.geo.found.entity.FoundItem;
 import com.locat.api.domain.geo.lost.entity.LostItem;
-import com.locat.api.domain.user.entity.User;
+import com.locat.api.domain.user.entity.EndUser;
 import jakarta.persistence.*;
 import java.util.Set;
 import lombok.AccessLevel;
@@ -31,7 +31,7 @@ public abstract class GeoItem extends SecuredBaseEntity {
       updatable = false,
       columnDefinition = "int UNSIGNED",
       foreignKey = @ForeignKey(ConstraintMode.NO_CONSTRAINT))
-  protected User user;
+  protected EndUser user;
 
   @ManyToOne(fetch = FetchType.LAZY)
   @JoinColumn(name = "category_id", foreignKey = @ForeignKey(ConstraintMode.NO_CONSTRAINT))

--- a/src/main/java/com/locat/api/domain/geo/found/entity/FoundItem.java
+++ b/src/main/java/com/locat/api/domain/geo/found/entity/FoundItem.java
@@ -4,7 +4,7 @@ import com.locat.api.domain.geo.base.entity.Category;
 import com.locat.api.domain.geo.base.entity.ColorCode;
 import com.locat.api.domain.geo.base.entity.GeoItem;
 import com.locat.api.domain.geo.found.dto.FoundItemRegisterDto;
-import com.locat.api.domain.user.entity.User;
+import com.locat.api.domain.user.entity.EndUser;
 import jakarta.persistence.*;
 import java.time.LocalDateTime;
 import java.util.HashSet;
@@ -48,7 +48,7 @@ public class FoundItem extends GeoItem {
   private FoundItemStatusType statusType;
 
   public static FoundItem of(
-      User user,
+      EndUser user,
       Category category,
       Set<ColorCode> colorCodes,
       FoundItemRegisterDto registerDto,

--- a/src/main/java/com/locat/api/domain/geo/found/service/impl/FoundItemServiceImpl.java
+++ b/src/main/java/com/locat/api/domain/geo/found/service/impl/FoundItemServiceImpl.java
@@ -8,6 +8,7 @@ import com.locat.api.domain.geo.found.dto.FoundItemRegisterDto;
 import com.locat.api.domain.geo.found.dto.FoundItemSearchDto;
 import com.locat.api.domain.geo.found.entity.FoundItem;
 import com.locat.api.domain.geo.found.service.FoundItemService;
+import com.locat.api.domain.user.entity.EndUser;
 import com.locat.api.domain.user.entity.User;
 import com.locat.api.domain.user.service.UserService;
 import com.locat.api.global.exception.ApiExceptionType;
@@ -56,7 +57,11 @@ public class FoundItemServiceImpl implements FoundItemService {
   @Override
   public Long register(
       Long userId, FoundItemRegisterDto registerDto, MultipartFile foundItemImage) {
-    User user = this.userService.findById(userId);
+    EndUser user =
+        this.userService
+            .findById(userId)
+            .map(User::asEndUser)
+            .orElseThrow(() -> new NoSuchEntityException(ApiExceptionType.NOT_FOUND_USER));
     final Category category = this.fetchCategoryById(registerDto.categoryId());
     final Set<ColorCode> colorCodes =
         registerDto.colorIds().stream().map(this::fetchColorCodeById).collect(Collectors.toSet());

--- a/src/main/java/com/locat/api/domain/geo/lost/entity/LostItem.java
+++ b/src/main/java/com/locat/api/domain/geo/lost/entity/LostItem.java
@@ -4,7 +4,7 @@ import com.locat.api.domain.geo.base.entity.Category;
 import com.locat.api.domain.geo.base.entity.ColorCode;
 import com.locat.api.domain.geo.base.entity.GeoItem;
 import com.locat.api.domain.geo.lost.dto.LostItemRegisterDto;
-import com.locat.api.domain.user.entity.User;
+import com.locat.api.domain.user.entity.EndUser;
 import jakarta.persistence.*;
 import java.time.LocalDateTime;
 import java.util.HashSet;
@@ -51,7 +51,7 @@ public class LostItem extends GeoItem {
   private LostItemStatusType statusType;
 
   public static LostItem of(
-      User user,
+      EndUser user,
       Category category,
       Set<ColorCode> colorCodes,
       LostItemRegisterDto registerDto,

--- a/src/main/java/com/locat/api/domain/geo/lost/service/impl/LostItemServiceImpl.java
+++ b/src/main/java/com/locat/api/domain/geo/lost/service/impl/LostItemServiceImpl.java
@@ -8,6 +8,7 @@ import com.locat.api.domain.geo.lost.dto.LostItemRegisterDto;
 import com.locat.api.domain.geo.lost.dto.LostItemSearchDto;
 import com.locat.api.domain.geo.lost.entity.LostItem;
 import com.locat.api.domain.geo.lost.service.LostItemService;
+import com.locat.api.domain.user.entity.EndUser;
 import com.locat.api.domain.user.entity.User;
 import com.locat.api.domain.user.service.UserService;
 import com.locat.api.global.exception.ApiExceptionType;
@@ -55,7 +56,11 @@ public class LostItemServiceImpl implements LostItemService {
 
   @Override
   public Long register(Long userId, LostItemRegisterDto registerDto, MultipartFile lostItemImage) {
-    final User user = this.userService.findById(userId);
+    final EndUser user =
+        this.userService
+            .findById(userId)
+            .map(User::asEndUser)
+            .orElseThrow(() -> new NoSuchEntityException(ApiExceptionType.NOT_FOUND_USER));
     final Category category = this.fetchCategoryById(registerDto.categoryId());
     final Set<ColorCode> colorCodes =
         registerDto.colorIds().stream().map(this::fetchColorCodeById).collect(Collectors.toSet());

--- a/src/main/java/com/locat/api/domain/user/dto/EndpointRegisterDto.java
+++ b/src/main/java/com/locat/api/domain/user/dto/EndpointRegisterDto.java
@@ -1,7 +1,7 @@
 package com.locat.api.domain.user.dto;
 
 import com.locat.api.domain.user.dto.request.EndpointRegisterRequest;
-import com.locat.api.domain.user.entity.PlatformType;
+import com.locat.api.domain.user.enums.PlatformType;
 
 public record EndpointRegisterDto(String deviceToken, PlatformType platformType) {
 

--- a/src/main/java/com/locat/api/domain/user/dto/KakaoUserInfoDto.java
+++ b/src/main/java/com/locat/api/domain/user/dto/KakaoUserInfoDto.java
@@ -3,7 +3,7 @@ package com.locat.api.domain.user.dto;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.databind.PropertyNamingStrategies;
 import com.fasterxml.jackson.databind.annotation.JsonNaming;
-import com.locat.api.domain.user.entity.OAuth2ProviderType;
+import com.locat.api.domain.user.enums.OAuth2ProviderType;
 
 public record KakaoUserInfoDto(String id, @JsonProperty("kakao_account") KakaoAccount kakaoAccount)
     implements OAuth2UserInfoDto {

--- a/src/main/java/com/locat/api/domain/user/dto/KakaoUserTermsAgreementDto.java
+++ b/src/main/java/com/locat/api/domain/user/dto/KakaoUserTermsAgreementDto.java
@@ -1,6 +1,6 @@
 package com.locat.api.domain.user.dto;
 
-import com.locat.api.domain.user.entity.OAuth2ProviderType;
+import com.locat.api.domain.user.enums.OAuth2ProviderType;
 import java.util.List;
 
 public record KakaoUserTermsAgreementDto(String id, List<AgreementDetails> agreementDetails)

--- a/src/main/java/com/locat/api/domain/user/dto/OAuth2ProviderTermsAgreementDto.java
+++ b/src/main/java/com/locat/api/domain/user/dto/OAuth2ProviderTermsAgreementDto.java
@@ -1,6 +1,6 @@
 package com.locat.api.domain.user.dto;
 
-import com.locat.api.domain.user.entity.OAuth2ProviderType;
+import com.locat.api.domain.user.enums.OAuth2ProviderType;
 import java.util.List;
 
 public interface OAuth2ProviderTermsAgreementDto {

--- a/src/main/java/com/locat/api/domain/user/dto/OAuth2UserInfoDto.java
+++ b/src/main/java/com/locat/api/domain/user/dto/OAuth2UserInfoDto.java
@@ -1,6 +1,6 @@
 package com.locat.api.domain.user.dto;
 
-import com.locat.api.domain.user.entity.OAuth2ProviderType;
+import com.locat.api.domain.user.enums.OAuth2ProviderType;
 
 public interface OAuth2UserInfoDto {
 

--- a/src/main/java/com/locat/api/domain/user/dto/request/EndpointRegisterRequest.java
+++ b/src/main/java/com/locat/api/domain/user/dto/request/EndpointRegisterRequest.java
@@ -1,6 +1,6 @@
 package com.locat.api.domain.user.dto.request;
 
-import com.locat.api.domain.user.entity.PlatformType;
+import com.locat.api.domain.user.enums.PlatformType;
 import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.Pattern;
 

--- a/src/main/java/com/locat/api/domain/user/dto/response/UserInfoResponse.java
+++ b/src/main/java/com/locat/api/domain/user/dto/response/UserInfoResponse.java
@@ -1,6 +1,6 @@
 package com.locat.api.domain.user.dto.response;
 
-import com.locat.api.domain.user.entity.User;
+import com.locat.api.domain.user.entity.EndUser;
 
 /**
  * 사용자 정보 조회 응답
@@ -19,7 +19,7 @@ public record UserInfoResponse(
     String profileImageUrl,
     String createdAt,
     String updatedAt) {
-  public static UserInfoResponse fromEntity(User user) {
+  public static UserInfoResponse fromEntity(EndUser user) {
     return new UserInfoResponse(
         user.getId(),
         user.getEmail(),

--- a/src/main/java/com/locat/api/domain/user/entity/AdminUser.java
+++ b/src/main/java/com/locat/api/domain/user/entity/AdminUser.java
@@ -1,0 +1,46 @@
+package com.locat.api.domain.user.entity;
+
+import com.locat.api.domain.user.entity.association.AdminDeviceId;
+import jakarta.persistence.*;
+import jakarta.validation.constraints.Size;
+import java.util.ArrayList;
+import java.util.List;
+import lombok.*;
+import lombok.experimental.SuperBuilder;
+
+@Entity
+@Getter
+@SuperBuilder
+@Table(name = "admin_user")
+@AllArgsConstructor(access = AccessLevel.PRIVATE)
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class AdminUser extends User {
+
+  @Size(max = 60)
+  @Column(name = "password", nullable = false, length = 60)
+  private String password;
+
+  @Column(name = "is_password_expired", nullable = false)
+  private boolean isPasswordExpired;
+
+  @OneToMany(mappedBy = "adminUser", cascade = CascadeType.ALL, orphanRemoval = true)
+  private List<AdminDeviceId> adminDeviceIds = new ArrayList<>();
+
+  public void resetPassword(String encodedPassword) {
+    this.password = encodedPassword;
+    this.isPasswordExpired = false;
+  }
+
+  public boolean isTrustedDevice(String deviceId) {
+    return this.adminDeviceIds.stream()
+        .anyMatch(device -> device.getDeviceId().equals(deviceId) && device.isTrusted());
+  }
+
+  public void addTrustedDevice(String deviceId, boolean isTrusted) {
+    this.adminDeviceIds.add(AdminDeviceId.of(this, deviceId, isTrusted));
+  }
+
+  public void removeTrustedDevice(String deviceId) {
+    this.adminDeviceIds.removeIf(device -> device.getDeviceId().equals(deviceId));
+  }
+}

--- a/src/main/java/com/locat/api/domain/user/entity/EndUser.java
+++ b/src/main/java/com/locat/api/domain/user/entity/EndUser.java
@@ -1,0 +1,74 @@
+package com.locat.api.domain.user.entity;
+
+import com.locat.api.domain.user.dto.OAuth2UserInfoDto;
+import com.locat.api.domain.user.entity.association.UserEndpoint;
+import com.locat.api.domain.user.entity.association.UserSetting;
+import com.locat.api.domain.user.entity.association.UserTermsAgreement;
+import com.locat.api.domain.user.enums.OAuth2ProviderType;
+import com.locat.api.domain.user.enums.StatusType;
+import com.locat.api.domain.user.enums.UserType;
+import com.locat.api.global.utils.HashingUtils;
+import jakarta.persistence.*;
+import jakarta.validation.constraints.Size;
+import java.util.ArrayList;
+import java.util.List;
+import lombok.*;
+import lombok.experimental.SuperBuilder;
+
+@Entity
+@Getter
+@SuperBuilder
+@Table(
+    name = "end_user",
+    uniqueConstraints = {
+      @UniqueConstraint(
+          name = "unique_oauth",
+          columnNames = {"oauth_type", "oauth_id"})
+    })
+@AllArgsConstructor(access = AccessLevel.PROTECTED)
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class EndUser extends User {
+
+  @Column(name = "oauth_id", nullable = false, length = 100)
+  private String oauthId;
+
+  @Enumerated(EnumType.STRING)
+  @Column(name = "oauth_type")
+  private OAuth2ProviderType oauthType;
+
+  @Size(max = 255)
+  @Column(name = "profile_image")
+  private String profileImage;
+
+  @OneToMany(mappedBy = "user", cascade = CascadeType.ALL, orphanRemoval = true)
+  private List<UserSetting> userSettings = new ArrayList<>();
+
+  @OneToMany(mappedBy = "user", cascade = CascadeType.ALL, orphanRemoval = true)
+  private List<UserTermsAgreement> termsAgreements = new ArrayList<>();
+
+  @OneToMany(mappedBy = "user", cascade = CascadeType.ALL, orphanRemoval = true)
+  private List<UserEndpoint> userEndpoints = new ArrayList<>();
+
+  public static EndUser of(String nickname, OAuth2UserInfoDto userInfo) {
+    return builder()
+        .nickname(nickname)
+        .email(userInfo.getEmail())
+        .emailHash(HashingUtils.hash(userInfo.getEmail()))
+        .oauthId(userInfo.getId())
+        .oauthType(userInfo.getProvider())
+        .userType(UserType.USER)
+        .statusType(StatusType.ACTIVE)
+        .build();
+  }
+
+  public EndUser update(String email, String nickname) {
+    if (email != null && emailHash != null) {
+      this.email = email;
+      this.emailHash = HashingUtils.hash(email);
+    }
+    if (nickname != null) {
+      this.nickname = nickname;
+    }
+    return this;
+  }
+}

--- a/src/main/java/com/locat/api/domain/user/entity/OAuth2ProviderType.java
+++ b/src/main/java/com/locat/api/domain/user/entity/OAuth2ProviderType.java
@@ -1,6 +1,0 @@
-package com.locat.api.domain.user.entity;
-
-public enum OAuth2ProviderType {
-  APPLE,
-  KAKAO;
-}

--- a/src/main/java/com/locat/api/domain/user/entity/UserType.java
+++ b/src/main/java/com/locat/api/domain/user/entity/UserType.java
@@ -1,6 +1,0 @@
-package com.locat.api.domain.user.entity;
-
-public enum UserType {
-  USER,
-  ADMIN
-}

--- a/src/main/java/com/locat/api/domain/user/entity/association/AdminDeviceId.java
+++ b/src/main/java/com/locat/api/domain/user/entity/association/AdminDeviceId.java
@@ -1,0 +1,47 @@
+package com.locat.api.domain.user.entity.association;
+
+import com.locat.api.domain.common.entity.BaseEntity;
+import com.locat.api.domain.user.entity.AdminUser;
+import jakarta.persistence.*;
+import lombok.*;
+
+@Entity
+@Getter
+@Builder
+@Table(
+    name = "admin_device_id",
+    uniqueConstraints = {
+      @UniqueConstraint(
+          name = "unique_admin_device_id",
+          columnNames = {"admin_user_id", "device_id"})
+    })
+@AllArgsConstructor(access = AccessLevel.PRIVATE)
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class AdminDeviceId extends BaseEntity {
+
+  @Id
+  @GeneratedValue(strategy = GenerationType.IDENTITY)
+  @Column(name = "id", columnDefinition = "int UNSIGNED not null")
+  private Long id;
+
+  @ManyToOne(fetch = FetchType.LAZY, optional = false)
+  @JoinColumn(
+      name = "admin_user_id",
+      nullable = false,
+      foreignKey = @ForeignKey(ConstraintMode.NO_CONSTRAINT))
+  private AdminUser adminUser;
+
+  @Column(name = "device_id", nullable = false)
+  private String deviceId;
+
+  @Column(name = "is_trusted", nullable = false)
+  private boolean isTrusted;
+
+  public static AdminDeviceId of(AdminUser adminUser, String deviceId, boolean isTrusted) {
+    return AdminDeviceId.builder()
+        .adminUser(adminUser)
+        .deviceId(deviceId)
+        .isTrusted(isTrusted)
+        .build();
+  }
+}

--- a/src/main/java/com/locat/api/domain/user/entity/association/UserEndpoint.java
+++ b/src/main/java/com/locat/api/domain/user/entity/association/UserEndpoint.java
@@ -1,7 +1,9 @@
-package com.locat.api.domain.user.entity;
+package com.locat.api.domain.user.entity.association;
 
 import com.locat.api.domain.common.entity.SecuredBaseEntity;
 import com.locat.api.domain.user.dto.EndpointRegisterDto;
+import com.locat.api.domain.user.entity.EndUser;
+import com.locat.api.domain.user.enums.PlatformType;
 import jakarta.persistence.*;
 import lombok.*;
 
@@ -20,7 +22,7 @@ public class UserEndpoint extends SecuredBaseEntity {
 
   @ManyToOne(fetch = FetchType.LAZY, optional = false)
   @JoinColumn(name = "user_id", nullable = false)
-  private User user;
+  private EndUser user;
 
   @Column(name = "device_token", nullable = false)
   private String deviceToken;
@@ -36,7 +38,7 @@ public class UserEndpoint extends SecuredBaseEntity {
   private String subscriptionArn;
 
   public static UserEndpoint of(
-      User user, String endpointArn, String subscriptionArn, EndpointRegisterDto registerDto) {
+      EndUser user, String endpointArn, String subscriptionArn, EndpointRegisterDto registerDto) {
     return UserEndpoint.builder()
         .user(user)
         .deviceToken(registerDto.deviceToken())

--- a/src/main/java/com/locat/api/domain/user/entity/association/UserSetting.java
+++ b/src/main/java/com/locat/api/domain/user/entity/association/UserSetting.java
@@ -1,7 +1,8 @@
-package com.locat.api.domain.user.entity;
+package com.locat.api.domain.user.entity.association;
 
 import com.locat.api.domain.common.entity.SecuredBaseEntity;
 import com.locat.api.domain.setting.AppSetting;
+import com.locat.api.domain.user.entity.EndUser;
 import jakarta.persistence.*;
 import jakarta.validation.constraints.NotNull;
 import lombok.*;
@@ -26,7 +27,7 @@ public class UserSetting extends SecuredBaseEntity {
 
   @ManyToOne(fetch = FetchType.EAGER, optional = false)
   @JoinColumn(name = "user_id", nullable = false, columnDefinition = "int UNSIGNED")
-  private User user;
+  private EndUser user;
 
   @ManyToOne(fetch = FetchType.EAGER)
   @JoinColumn(name = "setting_id", nullable = false, columnDefinition = "int UNSIGNED")
@@ -36,7 +37,7 @@ public class UserSetting extends SecuredBaseEntity {
   @Column(name = "value", nullable = false)
   private String value;
 
-  public static UserSetting ofDefault(User user, AppSetting appSetting) {
+  public static UserSetting ofDefault(EndUser user, AppSetting appSetting) {
     return UserSetting.builder()
         .user(user)
         .appSetting(appSetting)

--- a/src/main/java/com/locat/api/domain/user/entity/association/UserTermsAgreement.java
+++ b/src/main/java/com/locat/api/domain/user/entity/association/UserTermsAgreement.java
@@ -1,7 +1,8 @@
-package com.locat.api.domain.user.entity;
+package com.locat.api.domain.user.entity.association;
 
 import com.locat.api.domain.common.entity.SecuredBaseEntity;
 import com.locat.api.domain.terms.entity.Terms;
+import com.locat.api.domain.user.entity.EndUser;
 import jakarta.persistence.*;
 import lombok.*;
 
@@ -26,13 +27,13 @@ public class UserTermsAgreement extends SecuredBaseEntity {
 
   @ManyToOne(fetch = FetchType.LAZY, optional = false)
   @JoinColumn(name = "user_id", nullable = false)
-  private User user;
+  private EndUser user;
 
   @ManyToOne(fetch = FetchType.LAZY, optional = false)
   @JoinColumn(name = "terms_id", nullable = false)
   private Terms terms;
 
-  public static UserTermsAgreement of(User user, Terms agreement) {
+  public static UserTermsAgreement of(EndUser user, Terms agreement) {
     return UserTermsAgreement.builder().user(user).terms(agreement).build();
   }
 }

--- a/src/main/java/com/locat/api/domain/user/entity/association/UserWithdrawalLog.java
+++ b/src/main/java/com/locat/api/domain/user/entity/association/UserWithdrawalLog.java
@@ -1,4 +1,4 @@
-package com.locat.api.domain.user.entity;
+package com.locat.api.domain.user.entity.association;
 
 import com.locat.api.domain.common.entity.SecuredBaseEntity;
 import jakarta.persistence.*;

--- a/src/main/java/com/locat/api/domain/user/enums/OAuth2ProviderType.java
+++ b/src/main/java/com/locat/api/domain/user/enums/OAuth2ProviderType.java
@@ -1,0 +1,6 @@
+package com.locat.api.domain.user.enums;
+
+public enum OAuth2ProviderType {
+  APPLE,
+  KAKAO
+}

--- a/src/main/java/com/locat/api/domain/user/enums/PlatformType.java
+++ b/src/main/java/com/locat/api/domain/user/enums/PlatformType.java
@@ -1,4 +1,4 @@
-package com.locat.api.domain.user.entity;
+package com.locat.api.domain.user.enums;
 
 import com.locat.api.global.exception.ApiExceptionType;
 import com.locat.api.global.notification.NotificationException;

--- a/src/main/java/com/locat/api/domain/user/enums/StatusType.java
+++ b/src/main/java/com/locat/api/domain/user/enums/StatusType.java
@@ -1,4 +1,4 @@
-package com.locat.api.domain.user.entity;
+package com.locat.api.domain.user.enums;
 
 /** 사용자 상태 Enum */
 public enum StatusType {

--- a/src/main/java/com/locat/api/domain/user/enums/UserType.java
+++ b/src/main/java/com/locat/api/domain/user/enums/UserType.java
@@ -1,0 +1,11 @@
+package com.locat.api.domain.user.enums;
+
+public enum UserType {
+  USER,
+  ADMIN,
+  MANAGER;
+
+  public boolean isAdmin() {
+    return this == ADMIN || this == MANAGER;
+  }
+}

--- a/src/main/java/com/locat/api/domain/user/service/PlatformEndpointService.java
+++ b/src/main/java/com/locat/api/domain/user/service/PlatformEndpointService.java
@@ -1,6 +1,6 @@
 package com.locat.api.domain.user.service;
 
-import com.locat.api.domain.user.entity.PlatformType;
+import com.locat.api.domain.user.enums.PlatformType;
 
 public interface PlatformEndpointService {
 

--- a/src/main/java/com/locat/api/domain/user/service/UserEndpointService.java
+++ b/src/main/java/com/locat/api/domain/user/service/UserEndpointService.java
@@ -1,7 +1,7 @@
 package com.locat.api.domain.user.service;
 
 import com.locat.api.domain.user.dto.EndpointRegisterDto;
-import com.locat.api.domain.user.entity.UserEndpoint;
+import com.locat.api.domain.user.entity.association.UserEndpoint;
 import java.util.List;
 
 public interface UserEndpointService {

--- a/src/main/java/com/locat/api/domain/user/service/UserRegistrationService.java
+++ b/src/main/java/com/locat/api/domain/user/service/UserRegistrationService.java
@@ -1,8 +1,8 @@
 package com.locat.api.domain.user.service;
 
 import com.locat.api.domain.user.dto.UserRegisterDto;
-import com.locat.api.domain.user.entity.User;
+import com.locat.api.domain.user.entity.EndUser;
 
 public interface UserRegistrationService {
-  User register(final UserRegisterDto userRegisterDto);
+  EndUser register(final UserRegisterDto userRegisterDto);
 }

--- a/src/main/java/com/locat/api/domain/user/service/UserService.java
+++ b/src/main/java/com/locat/api/domain/user/service/UserService.java
@@ -1,15 +1,12 @@
 package com.locat.api.domain.user.service;
 
 import com.locat.api.domain.user.dto.UserInfoUpdateDto;
+import com.locat.api.domain.user.entity.EndUser;
 import com.locat.api.domain.user.entity.User;
 import com.locat.api.global.exception.NoSuchEntityException;
 import java.util.Optional;
 
 public interface UserService {
-
-  User save(final User user);
-
-  User update(final Long id, final UserInfoUpdateDto infoUpdateDto);
 
   /**
    * 사용자 ID로 사용자 조회
@@ -18,9 +15,21 @@ public interface UserService {
    * @return 사용자 정보
    * @throws NoSuchEntityException 해당 ID의 사용자가 없을 경우
    */
-  User findById(final Long id);
+  Optional<User> findById(final Long id);
 
-  Optional<User> findByOAuthId(final String oAuthId);
+  /**
+   * 사용자 이메일 해시로 사용자 조회
+   *
+   * @param email 사용자 이메일(Not Hashed)
+   * @return 사용자 정보
+   */
+  Optional<User> findByEmail(final String email);
+
+  EndUser save(final EndUser user);
+
+  EndUser update(final Long id, final UserInfoUpdateDto infoUpdateDto);
+
+  Optional<EndUser> findEndUserByOAuthId(final String oAuthId);
 
   /**
    * 사용자 탈퇴

--- a/src/main/java/com/locat/api/domain/user/service/UserSettingService.java
+++ b/src/main/java/com/locat/api/domain/user/service/UserSettingService.java
@@ -1,8 +1,8 @@
 package com.locat.api.domain.user.service;
 
-import com.locat.api.domain.user.entity.User;
+import com.locat.api.domain.user.entity.EndUser;
 
 public interface UserSettingService {
 
-  void registerDefaultSettings(final User user);
+  void registerDefaultSettings(final EndUser user);
 }

--- a/src/main/java/com/locat/api/domain/user/service/UserTermsService.java
+++ b/src/main/java/com/locat/api/domain/user/service/UserTermsService.java
@@ -1,9 +1,9 @@
 package com.locat.api.domain.user.service;
 
 import com.locat.api.domain.user.dto.UserRegisterDto;
-import com.locat.api.domain.user.entity.User;
+import com.locat.api.domain.user.entity.EndUser;
 
 public interface UserTermsService {
 
-  void register(User user, UserRegisterDto registerDto);
+  void register(EndUser user, UserRegisterDto registerDto);
 }

--- a/src/main/java/com/locat/api/domain/user/service/impl/PlatformEndpointServiceImpl.java
+++ b/src/main/java/com/locat/api/domain/user/service/impl/PlatformEndpointServiceImpl.java
@@ -2,7 +2,7 @@ package com.locat.api.domain.user.service.impl;
 
 import static com.locat.api.infrastructure.aws.AwsSnsProperties.DEFAULT_SNS_PROTOCOL;
 
-import com.locat.api.domain.user.entity.PlatformType;
+import com.locat.api.domain.user.enums.PlatformType;
 import com.locat.api.domain.user.exception.UserEndpointException;
 import com.locat.api.domain.user.service.PlatformEndpointService;
 import com.locat.api.global.exception.ApiExceptionType;

--- a/src/main/java/com/locat/api/domain/user/service/impl/UserEndpointServiceImpl.java
+++ b/src/main/java/com/locat/api/domain/user/service/impl/UserEndpointServiceImpl.java
@@ -1,11 +1,14 @@
 package com.locat.api.domain.user.service.impl;
 
 import com.locat.api.domain.user.dto.EndpointRegisterDto;
+import com.locat.api.domain.user.entity.EndUser;
 import com.locat.api.domain.user.entity.User;
-import com.locat.api.domain.user.entity.UserEndpoint;
+import com.locat.api.domain.user.entity.association.UserEndpoint;
 import com.locat.api.domain.user.service.PlatformEndpointService;
 import com.locat.api.domain.user.service.UserEndpointService;
 import com.locat.api.domain.user.service.UserService;
+import com.locat.api.global.exception.ApiExceptionType;
+import com.locat.api.global.exception.NoSuchEntityException;
 import com.locat.api.infrastructure.repository.user.UserEndpointRepository;
 import java.util.List;
 import lombok.RequiredArgsConstructor;
@@ -23,7 +26,11 @@ public class UserEndpointServiceImpl implements UserEndpointService {
 
   @Override
   public void register(Long userId, EndpointRegisterDto registerDto) {
-    User user = this.userService.findById(userId);
+    EndUser user =
+        this.userService
+            .findById(userId)
+            .map(User::asEndUser)
+            .orElseThrow(() -> new NoSuchEntityException(ApiExceptionType.NOT_FOUND_USER));
     List<UserEndpoint> userEndpoints = this.findUserEndpointsByUserId(userId);
 
     if (this.isEndpointExists(registerDto, userEndpoints)) {

--- a/src/main/java/com/locat/api/domain/user/service/impl/UserRegistrationServiceImpl.java
+++ b/src/main/java/com/locat/api/domain/user/service/impl/UserRegistrationServiceImpl.java
@@ -5,7 +5,7 @@ import com.locat.api.domain.auth.template.OAuth2Template;
 import com.locat.api.domain.auth.template.OAuth2TemplateFactory;
 import com.locat.api.domain.user.dto.OAuth2UserInfoDto;
 import com.locat.api.domain.user.dto.UserRegisterDto;
-import com.locat.api.domain.user.entity.User;
+import com.locat.api.domain.user.entity.EndUser;
 import com.locat.api.domain.user.enums.UserInfoValidationType;
 import com.locat.api.domain.user.service.*;
 import com.locat.api.global.exception.ApiExceptionType;
@@ -29,13 +29,14 @@ public class UserRegistrationServiceImpl implements UserRegistrationService {
   private final OAuth2ProviderTokenRepository providerTokenRepository;
 
   @Override
-  public User register(UserRegisterDto userRegisterDto) {
+  public EndUser register(UserRegisterDto userRegisterDto) {
     this.assertUserNotExists(userRegisterDto.oAuthId());
     this.userValidationService.validateNickname(userRegisterDto.nickname());
 
     OAuth2ProviderToken token = this.findTokenById(userRegisterDto.oAuthId());
     OAuth2UserInfoDto userInfo = this.fetchUserInfo(token);
-    final User user = User.of(userRegisterDto.nickname(), userInfo); // TODO: 프로필 URL 선택 & 저장 로직 추가
+    final EndUser user =
+        EndUser.of(userRegisterDto.nickname(), userInfo); // TODO: 프로필 URL 선택 & 저장 로직 추가
 
     this.userService.save(user);
     this.userSettingService.registerDefaultSettings(user);

--- a/src/main/java/com/locat/api/domain/user/service/impl/UserSettingServiceImpl.java
+++ b/src/main/java/com/locat/api/domain/user/service/impl/UserSettingServiceImpl.java
@@ -1,7 +1,7 @@
 package com.locat.api.domain.user.service.impl;
 
-import com.locat.api.domain.user.entity.User;
-import com.locat.api.domain.user.entity.UserSetting;
+import com.locat.api.domain.user.entity.EndUser;
+import com.locat.api.domain.user.entity.association.UserSetting;
 import com.locat.api.domain.user.service.UserSettingService;
 import com.locat.api.infrastructure.repository.setting.AppSettingRepository;
 import com.locat.api.infrastructure.repository.user.UserSettingRepository;
@@ -19,7 +19,7 @@ public class UserSettingServiceImpl implements UserSettingService {
   private final UserSettingRepository userSettingRepository;
 
   @Override
-  public void registerDefaultSettings(User user) {
+  public void registerDefaultSettings(EndUser user) {
     List<UserSetting> userSettings =
         this.appSettingRepository.findAll().stream()
             .map(setting -> UserSetting.ofDefault(user, setting))

--- a/src/main/java/com/locat/api/domain/user/service/impl/UserTermsServiceImpl.java
+++ b/src/main/java/com/locat/api/domain/user/service/impl/UserTermsServiceImpl.java
@@ -3,8 +3,8 @@ package com.locat.api.domain.user.service.impl;
 import com.locat.api.domain.terms.entity.Terms;
 import com.locat.api.domain.terms.entity.TermsType;
 import com.locat.api.domain.user.dto.UserRegisterDto;
-import com.locat.api.domain.user.entity.User;
-import com.locat.api.domain.user.entity.UserTermsAgreement;
+import com.locat.api.domain.user.entity.EndUser;
+import com.locat.api.domain.user.entity.association.UserTermsAgreement;
 import com.locat.api.domain.user.service.UserTermsService;
 import com.locat.api.global.exception.InternalProcessingException;
 import com.locat.api.infrastructure.repository.terms.TermsQRepository;
@@ -24,13 +24,13 @@ public class UserTermsServiceImpl implements UserTermsService {
   private final UserTermsAgreementRepository userTermsAgreementRepository;
 
   @Override
-  public void register(User user, UserRegisterDto registerDto) {
+  public void register(EndUser user, UserRegisterDto registerDto) {
     List<UserTermsAgreement> userTermsAgreements = this.createUserTermsAgreement(user, registerDto);
     this.userTermsAgreementRepository.saveAll(userTermsAgreements);
   }
 
   private List<UserTermsAgreement> createUserTermsAgreement(
-      User user, UserRegisterDto registerDto) {
+      EndUser user, UserRegisterDto registerDto) {
     List<UserTermsAgreement> userTermsAgreements = new ArrayList<>();
     List<Terms> latestTermsList = this.termsQRepository.findAllLatest();
     if (Boolean.TRUE.equals(registerDto.isTermsOfServiceAgreed())) {

--- a/src/main/java/com/locat/api/domain/user/service/impl/UserValidationServiceImpl.java
+++ b/src/main/java/com/locat/api/domain/user/service/impl/UserValidationServiceImpl.java
@@ -10,7 +10,7 @@ import com.locat.api.global.exception.ApiExceptionType;
 import com.locat.api.global.exception.DuplicatedException;
 import com.locat.api.global.exception.InvalidParameterException;
 import com.locat.api.global.utils.HashingUtils;
-import com.locat.api.infrastructure.repository.user.UserRepository;
+import com.locat.api.infrastructure.repository.user.EndUserRepository;
 import java.util.List;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
@@ -20,7 +20,7 @@ import org.springframework.transaction.annotation.Transactional;
 @RequiredArgsConstructor
 public class UserValidationServiceImpl implements UserValidationService {
 
-  private final UserRepository userRepository;
+  private final EndUserRepository userRepository;
 
   @Override
   @Transactional(readOnly = true)

--- a/src/main/java/com/locat/api/domain/user/service/impl/UserWithdrawalLogServiceImpl.java
+++ b/src/main/java/com/locat/api/domain/user/service/impl/UserWithdrawalLogServiceImpl.java
@@ -1,6 +1,6 @@
 package com.locat.api.domain.user.service.impl;
 
-import com.locat.api.domain.user.entity.UserWithdrawalLog;
+import com.locat.api.domain.user.entity.association.UserWithdrawalLog;
 import com.locat.api.domain.user.service.UserWithdrawalLogService;
 import com.locat.api.infrastructure.repository.user.UserWithdrawalLogRepository;
 import lombok.RequiredArgsConstructor;

--- a/src/main/java/com/locat/api/global/auth/LocatUserDetailsService.java
+++ b/src/main/java/com/locat/api/global/auth/LocatUserDetailsService.java
@@ -7,13 +7,13 @@ import org.springframework.security.core.userdetails.UserDetailsService;
 public interface LocatUserDetailsService extends UserDetailsService {
 
   /**
-   * 사용자 ID로 인증 객체 {@link Authentication}을 생성합니다.
+   * 사용자 Email로 인증 객체 {@link Authentication}을 생성합니다.
    *
-   * @param userId 사용자 ID
+   * @param userEmail 사용자 Email
    * @return 인증 객체 {@link Authentication}
    * @throws NoSuchEntityException 해당 ID를 가지는 사용자가 없을 경우
    */
-  Authentication createAuthentication(String userId);
+  Authentication createAuthentication(String userEmail);
 
   /**
    * 인증 객체로부터 권한 정보를 추출합니다.

--- a/src/main/java/com/locat/api/global/auth/impl/LocatUserDetailsImpl.java
+++ b/src/main/java/com/locat/api/global/auth/impl/LocatUserDetailsImpl.java
@@ -33,7 +33,7 @@ public record LocatUserDetailsImpl(User user) implements LocatUserDetails, Seria
 
   @Override
   public String getUsername() {
-    return this.user.getId().toString();
+    return this.user.getEmail();
   }
 
   @Override

--- a/src/main/java/com/locat/api/global/auth/impl/LocatUserDetailsServiceImpl.java
+++ b/src/main/java/com/locat/api/global/auth/impl/LocatUserDetailsServiceImpl.java
@@ -1,7 +1,10 @@
 package com.locat.api.global.auth.impl;
 
+import com.locat.api.domain.user.entity.User;
 import com.locat.api.domain.user.service.UserService;
 import com.locat.api.global.auth.LocatUserDetailsService;
+import com.locat.api.global.exception.ApiExceptionType;
+import com.locat.api.global.exception.NoSuchEntityException;
 import java.util.stream.Collectors;
 import lombok.RequiredArgsConstructor;
 import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
@@ -17,13 +20,17 @@ public class LocatUserDetailsServiceImpl implements LocatUserDetailsService {
   private final UserService userService;
 
   @Override
-  public UserDetails loadUserByUsername(String userId) {
-    return LocatUserDetailsImpl.from(this.userService.findById(Long.parseLong(userId)));
+  public UserDetails loadUserByUsername(String username) {
+    User user =
+        this.userService
+            .findByEmail(username)
+            .orElseThrow(() -> new NoSuchEntityException(ApiExceptionType.NOT_FOUND_USER));
+    return LocatUserDetailsImpl.from(user);
   }
 
   @Override
-  public Authentication createAuthentication(String userId) {
-    UserDetails userDetails = this.loadUserByUsername(userId);
+  public Authentication createAuthentication(String userEmail) {
+    UserDetails userDetails = this.loadUserByUsername(userEmail);
     return new UsernamePasswordAuthenticationToken(userDetails, null, userDetails.getAuthorities());
   }
 

--- a/src/main/java/com/locat/api/global/auth/jwt/JwtProvider.java
+++ b/src/main/java/com/locat/api/global/auth/jwt/JwtProvider.java
@@ -1,6 +1,6 @@
 package com.locat.api.global.auth.jwt;
 
-import com.locat.api.domain.user.entity.User;
+import com.locat.api.domain.user.entity.EndUser;
 import io.jsonwebtoken.Claims;
 import io.jsonwebtoken.ExpiredJwtException;
 import jakarta.servlet.http.HttpServletRequest;
@@ -8,13 +8,13 @@ import jakarta.servlet.http.HttpServletRequest;
 public interface JwtProvider {
 
   /**
-   * {@link User}의 ID를 기반으로 서버 토큰을 생성합니다.
+   * {@link EndUser}의 ID를 기반으로 서버 토큰을 생성합니다.
    *
-   * @param userId 사용자 ID
+   * @param userEmail 사용자 Email
    * @return 토큰 발급 응답 DTO
    * @apiNote 갱신 토큰은 캐시 저장소에 저장됩니다.
    */
-  LocatTokenDto create(Long userId);
+  LocatTokenDto create(String userEmail);
 
   /**
    * 액세스 토큰을 갱신합니다.

--- a/src/main/java/com/locat/api/global/notification/NotificationServiceImpl.java
+++ b/src/main/java/com/locat/api/global/notification/NotificationServiceImpl.java
@@ -1,6 +1,6 @@
 package com.locat.api.global.notification;
 
-import com.locat.api.domain.user.entity.UserEndpoint;
+import com.locat.api.domain.user.entity.association.UserEndpoint;
 import com.locat.api.domain.user.service.UserEndpointService;
 import com.locat.api.global.exception.ApiExceptionType;
 import java.util.HashSet;

--- a/src/main/java/com/locat/api/infrastructure/aws/AwsSnsProperties.java
+++ b/src/main/java/com/locat/api/infrastructure/aws/AwsSnsProperties.java
@@ -1,6 +1,6 @@
 package com.locat.api.infrastructure.aws;
 
-import com.locat.api.domain.user.entity.PlatformType;
+import com.locat.api.domain.user.enums.PlatformType;
 import java.util.Collections;
 import java.util.EnumMap;
 import java.util.Map;

--- a/src/main/java/com/locat/api/infrastructure/redis/LocatRefreshTokenRepository.java
+++ b/src/main/java/com/locat/api/infrastructure/redis/LocatRefreshTokenRepository.java
@@ -1,6 +1,10 @@
 package com.locat.api.infrastructure.redis;
 
 import com.locat.api.domain.auth.entity.LocatRefreshToken;
+import java.util.Optional;
 import org.springframework.data.repository.CrudRepository;
 
-public interface LocatRefreshTokenRepository extends CrudRepository<LocatRefreshToken, Long> {}
+public interface LocatRefreshTokenRepository extends CrudRepository<LocatRefreshToken, Long> {
+
+  Optional<LocatRefreshToken> findByEmail(final String email);
+}

--- a/src/main/java/com/locat/api/infrastructure/repository/user/EndUserRepository.java
+++ b/src/main/java/com/locat/api/infrastructure/repository/user/EndUserRepository.java
@@ -1,0 +1,16 @@
+package com.locat.api.infrastructure.repository.user;
+
+import com.locat.api.domain.user.entity.EndUser;
+import java.util.Optional;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface EndUserRepository extends JpaRepository<EndUser, Long> {
+
+  Optional<EndUser> findByOauthId(String oauthId);
+
+  boolean existsByOauthId(String oauthId);
+
+  boolean existsByEmailHash(String emailHash);
+
+  boolean existsByNickname(String nickname);
+}

--- a/src/main/java/com/locat/api/infrastructure/repository/user/UserEndpointRepository.java
+++ b/src/main/java/com/locat/api/infrastructure/repository/user/UserEndpointRepository.java
@@ -1,6 +1,6 @@
 package com.locat.api.infrastructure.repository.user;
 
-import com.locat.api.domain.user.entity.UserEndpoint;
+import com.locat.api.domain.user.entity.association.UserEndpoint;
 import java.util.List;
 import org.springframework.data.jpa.repository.JpaRepository;
 

--- a/src/main/java/com/locat/api/infrastructure/repository/user/UserRepository.java
+++ b/src/main/java/com/locat/api/infrastructure/repository/user/UserRepository.java
@@ -5,12 +5,5 @@ import java.util.Optional;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 public interface UserRepository extends JpaRepository<User, Long> {
-
-  Optional<User> findByOauthId(String oauthId);
-
-  boolean existsByOauthId(String oauthId);
-
-  boolean existsByEmailHash(String emailHash);
-
-  boolean existsByNickname(String nickname);
+  Optional<User> findByEmailHash(String emailHash);
 }

--- a/src/main/java/com/locat/api/infrastructure/repository/user/UserSettingRepository.java
+++ b/src/main/java/com/locat/api/infrastructure/repository/user/UserSettingRepository.java
@@ -1,6 +1,6 @@
 package com.locat.api.infrastructure.repository.user;
 
-import com.locat.api.domain.user.entity.UserSetting;
+import com.locat.api.domain.user.entity.association.UserSetting;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 public interface UserSettingRepository extends JpaRepository<UserSetting, Long> {}

--- a/src/main/java/com/locat/api/infrastructure/repository/user/UserTermsAgreementRepository.java
+++ b/src/main/java/com/locat/api/infrastructure/repository/user/UserTermsAgreementRepository.java
@@ -1,6 +1,6 @@
 package com.locat.api.infrastructure.repository.user;
 
-import com.locat.api.domain.user.entity.UserTermsAgreement;
+import com.locat.api.domain.user.entity.association.UserTermsAgreement;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 public interface UserTermsAgreementRepository extends JpaRepository<UserTermsAgreement, Long> {}

--- a/src/main/java/com/locat/api/infrastructure/repository/user/UserWithdrawalLogRepository.java
+++ b/src/main/java/com/locat/api/infrastructure/repository/user/UserWithdrawalLogRepository.java
@@ -1,6 +1,6 @@
 package com.locat.api.infrastructure.repository.user;
 
-import com.locat.api.domain.user.entity.UserWithdrawalLog;
+import com.locat.api.domain.user.entity.association.UserWithdrawalLog;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 public interface UserWithdrawalLogRepository extends JpaRepository<UserWithdrawalLog, Long> {}

--- a/src/main/resources/db/migration/develop/V9__addAdminEntity.sql
+++ b/src/main/resources/db/migration/develop/V9__addAdminEntity.sql
@@ -1,0 +1,65 @@
+CREATE TABLE admin_user
+(
+    id                  INT UNSIGNED NOT NULL COMMENT '관리자 ID',
+    password            VARCHAR(60)  NOT NULL COMMENT '비밀번호',
+    is_password_expired TINYINT(1)   NOT NULL DEFAULT 0 COMMENT '비밀번호 만료 여부',
+    CONSTRAINT pk_admin_user PRIMARY KEY (id)
+) COMMENT '관리자 사용자 정보',
+    CHARSET = 'UTF8MB4',
+    COLLATE = 'UTF8MB4_GENERAL_CI',
+    ROW_FORMAT = Dynamic,
+    ENGINE = InnoDB;
+
+ALTER TABLE admin_user
+    ADD CONSTRAINT fk_admin_user_on_id FOREIGN KEY (id) REFERENCES user (id);
+
+CREATE TABLE admin_device_id
+(
+    id            INT UNSIGNED AUTO_INCREMENT NOT NULL COMMENT '관리자 디바이스 ID',
+    admin_user_id INT UNSIGNED                NOT NULL COMMENT '관리자 ID',
+    device_id     VARCHAR(255)                NOT NULL COMMENT '디바이스의 FingerPrint',
+    is_trusted    TINYINT(1)                  NOT NULL DEFAULT 0 COMMENT '신뢰 디바이스 여부',
+    created_at    datetime                    NOT NULL DEFAULT CURRENT_TIMESTAMP COMMENT '생성일',
+    updated_at    datetime                    NOT NULL DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP COMMENT '수정일',
+    CONSTRAINT pk_admin_device_id PRIMARY KEY (id)
+) COMMENT '관리자 디바이스 정보',
+    CHARSET = 'UTF8MB4',
+    COLLATE = 'UTF8MB4_GENERAL_CI',
+    ROW_FORMAT = Dynamic,
+    ENGINE = InnoDB;
+
+ALTER TABLE admin_device_id
+    ADD CONSTRAINT unique_admin_device UNIQUE (admin_user_id, device_id);
+
+CREATE TABLE end_user
+(
+    id            INT UNSIGNED            NOT NULL COMMENT '사용자 ID',
+    oauth_id      VARCHAR(100)            NOT NULL COMMENT '소셜 로그인 ID',
+    oauth_type    enum ('KAKAO', 'APPLE') NULL COMMENT '소셜 로그인 타입',
+    profile_image VARCHAR(255)            NULL COMMENT '프로필 이미지',
+    CONSTRAINT pk_end_user PRIMARY KEY (id)
+) COMMENT '일반 사용자 정보',
+    CHARSET = 'UTF8MB4',
+    COLLATE = 'UTF8MB4_GENERAL_CI',
+    ROW_FORMAT = Dynamic,
+    ENGINE = InnoDB;
+
+ALTER TABLE end_user
+    ADD CONSTRAINT unique_oauth UNIQUE (oauth_type, oauth_id);
+
+ALTER TABLE end_user
+    ADD CONSTRAINT fk_end_user_on_id FOREIGN KEY (id) REFERENCES user (id);
+
+ALTER TABLE user
+    DROP KEY unique_oauth_id;
+
+ALTER TABLE user
+    DROP COLUMN oauth_id;
+ALTER TABLE user
+    DROP COLUMN oauth_type;
+ALTER TABLE user
+    DROP COLUMN profile_image;
+
+alter table user
+    modify user_type enum ('USER', 'ADMIN', 'MANAGER') default 'USER' null comment '권한';
+

--- a/src/main/resources/logback-spring.xml
+++ b/src/main/resources/logback-spring.xml
@@ -31,7 +31,7 @@
         </logger>
     </springProfile>
 
-    <root level="INFO">
+    <root level="DEBUG">
         <appender-ref ref="STDOUT"/>
     </root>
 

--- a/src/test/java/com/locat/api/unit/entity/EndUserEntityTest.java
+++ b/src/test/java/com/locat/api/unit/entity/EndUserEntityTest.java
@@ -4,10 +4,10 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatCode;
 
 import com.locat.api.domain.user.dto.OAuth2UserInfoDto;
-import com.locat.api.domain.user.entity.OAuth2ProviderType;
-import com.locat.api.domain.user.entity.StatusType;
-import com.locat.api.domain.user.entity.User;
-import com.locat.api.domain.user.entity.UserType;
+import com.locat.api.domain.user.entity.EndUser;
+import com.locat.api.domain.user.enums.OAuth2ProviderType;
+import com.locat.api.domain.user.enums.StatusType;
+import com.locat.api.domain.user.enums.UserType;
 import com.locat.api.global.utils.HashingUtils;
 import com.locat.api.helper.TestDataFactory;
 import org.junit.jupiter.api.BeforeEach;
@@ -17,7 +17,7 @@ import org.mockito.InjectMocks;
 import org.mockito.MockitoAnnotations;
 import org.springframework.security.access.AccessDeniedException;
 
-class UserEntityTest {
+class EndUserEntityTest {
 
   private static final String EMAIL = "user@example.com";
   private static final String OAUTH_ID = "512351278326";
@@ -26,14 +26,14 @@ class UserEntityTest {
   private static final String PROFILE_IMAGE = "profile.jpg";
   private static final UserType USER_TYPE = UserType.ADMIN;
   private static final StatusType STATUS_TYPE = StatusType.ACTIVE;
-  @InjectMocks private User user;
+  @InjectMocks private EndUser user;
 
   @BeforeEach
   void setUp() {
     MockitoAnnotations.openMocks(this);
     // Given
     this.user =
-        User.builder()
+        EndUser.builder()
             .email(EMAIL)
             .emailHash(HashingUtils.hash(EMAIL))
             .oauthId(OAUTH_ID)
@@ -72,7 +72,7 @@ class UserEntityTest {
     OAuth2UserInfoDto mockUserInfoDto = TestDataFactory.create(OAUTH_ID, EMAIL);
 
     // When
-    User createdUser = User.of(NICKNAME, mockUserInfoDto);
+    EndUser createdUser = EndUser.of(NICKNAME, mockUserInfoDto);
 
     // Then
     assertThat(createdUser).isNotNull();
@@ -98,7 +98,7 @@ class UserEntityTest {
     String newNickname = "newUser";
 
     // When
-    User updatedUser = this.user.update(newEmail, newNickname);
+    EndUser updatedUser = this.user.update(newEmail, newNickname);
 
     // Then
     assertThat(updatedUser.getEmail()).isEqualTo(newEmail);
@@ -110,7 +110,7 @@ class UserEntityTest {
   @DisplayName("null이 주어지면, User 객체의 필드 값을 업데이트하지 않아야 한다.")
   void testUpdateWithNull() {
     // Given & When
-    User updatedUser = this.user.update(null, null);
+    EndUser updatedUser = this.user.update(null, null);
 
     // Then
     assertThat(updatedUser.getEmail()).isEqualTo(EMAIL);

--- a/src/test/java/com/locat/api/unit/entity/EndUserRelatedEntityTest.java
+++ b/src/test/java/com/locat/api/unit/entity/EndUserRelatedEntityTest.java
@@ -2,11 +2,11 @@ package com.locat.api.unit.entity;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
-import com.locat.api.domain.user.entity.UserWithdrawalLog;
+import com.locat.api.domain.user.entity.association.UserWithdrawalLog;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 
-class UserRelatedEntityTest {
+class EndUserRelatedEntityTest {
 
   @Test
   @DisplayName("UserWithdrawalLog Entity 생성 테스트")

--- a/src/test/java/com/locat/api/unit/entity/FoundItemEntityTest.java
+++ b/src/test/java/com/locat/api/unit/entity/FoundItemEntityTest.java
@@ -7,7 +7,7 @@ import com.locat.api.domain.geo.base.entity.ColorCode;
 import com.locat.api.domain.geo.found.dto.FoundItemRegisterDto;
 import com.locat.api.domain.geo.found.entity.FoundItem;
 import com.locat.api.domain.geo.found.entity.FoundItemStatusType;
-import com.locat.api.domain.user.entity.User;
+import com.locat.api.domain.user.entity.EndUser;
 import com.locat.api.helper.TestDataFactory;
 import java.util.HashSet;
 import java.util.Set;
@@ -32,7 +32,7 @@ class FoundItemEntityTest {
     MockitoAnnotations.openMocks(this);
 
     // Mock 데이터 준비
-    User mockUser = Mockito.mock(User.class);
+    EndUser mockUser = Mockito.mock(EndUser.class);
     Category mockCategory = Mockito.mock(Category.class);
     Set<ColorCode> mockColorCodes =
         new HashSet<>(Set.of(ColorCode.of("#FF0000", "Red"), ColorCode.of("#000000", "Black")));

--- a/src/test/java/com/locat/api/unit/entity/LocatRefreshTokenTest.java
+++ b/src/test/java/com/locat/api/unit/entity/LocatRefreshTokenTest.java
@@ -12,6 +12,7 @@ import org.junit.jupiter.api.Test;
 class LocatRefreshTokenTest {
 
   private static final Long ID = 1L;
+  private static final String EMAIL = "test@locat.kr";
   private static final String REFRESH_TOKEN = "sample_refresh_token";
   private static final Duration EXPIRATION_TIME = Duration.ofHours(1);
 
@@ -20,9 +21,10 @@ class LocatRefreshTokenTest {
   @BeforeEach
   void setUp() {
     // Given
-    locatRefreshToken =
+    this.locatRefreshToken =
         LocatRefreshToken.builder()
             .id(ID)
+            .email(EMAIL)
             .refreshToken(REFRESH_TOKEN)
             .refreshTokenExpiresIn(EXPIRATION_TIME.toSeconds())
             .build();
@@ -33,9 +35,10 @@ class LocatRefreshTokenTest {
   void testLocatRefreshTokenBuilder() {
     // When & Then
     assertAll(
-        () -> assertThat(locatRefreshToken).isNotNull(),
-        () -> assertThat(locatRefreshToken.getId()).isEqualTo(ID),
-        () -> assertThat(locatRefreshToken.getRefreshToken()).isEqualTo(REFRESH_TOKEN),
+        () -> assertThat(this.locatRefreshToken).isNotNull(),
+        () -> assertThat(this.locatRefreshToken.getId()).isEqualTo(ID),
+        () -> assertThat(this.locatRefreshToken.getEmail()).isEqualTo(EMAIL),
+        () -> assertThat(this.locatRefreshToken.getRefreshToken()).isEqualTo(REFRESH_TOKEN),
         () ->
             assertThat(locatRefreshToken.getRefreshTokenExpiresIn())
                 .isEqualTo(EXPIRATION_TIME.toSeconds()));
@@ -48,7 +51,7 @@ class LocatRefreshTokenTest {
     Duration expirationTime = Duration.ofHours(2);
 
     // When
-    LocatRefreshToken newToken = LocatRefreshToken.from(ID, REFRESH_TOKEN, expirationTime);
+    LocatRefreshToken newToken = LocatRefreshToken.from(ID, EMAIL, REFRESH_TOKEN, expirationTime);
 
     // Then
     assertAll(
@@ -65,7 +68,7 @@ class LocatRefreshTokenTest {
   void testIsNotMatched() {
     // When & Then
     assertAll(
-        () -> assertThat(locatRefreshToken.isNotMatched("wrong_token")).isTrue(),
-        () -> assertThat(locatRefreshToken.isNotMatched(REFRESH_TOKEN)).isFalse());
+        () -> assertThat(this.locatRefreshToken.isNotMatched("wrong_token")).isTrue(),
+        () -> assertThat(this.locatRefreshToken.isNotMatched(REFRESH_TOKEN)).isFalse());
   }
 }

--- a/src/test/java/com/locat/api/unit/jwt/JwtProviderTest.java
+++ b/src/test/java/com/locat/api/unit/jwt/JwtProviderTest.java
@@ -4,6 +4,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatCode;
 import static org.mockito.Mockito.*;
 
+import com.locat.api.domain.user.entity.User;
 import com.locat.api.global.auth.LocatUserDetails;
 import com.locat.api.global.auth.LocatUserDetailsService;
 import com.locat.api.global.auth.jwt.JwtProviderImpl;
@@ -54,15 +55,19 @@ class JwtProviderTest {
   @DisplayName("JWT 생성 테스트")
   void shouldCreateTokenDto() {
     // Given
-    String userIdStr = "1";
+    String userEmail = "test@locat.kr";
+    User user = mock(User.class);
     LocatUserDetails userDetails = mock(LocatUserDetails.class);
     Authentication authentication = mock(Authentication.class);
-    when(this.userDetailsService.loadUserByUsername(userIdStr)).thenReturn(userDetails);
-    when(this.userDetailsService.createAuthentication(userIdStr)).thenReturn(authentication);
-    when(authentication.getName()).thenReturn(userIdStr);
+    when(this.userDetailsService.loadUserByUsername(userEmail)).thenReturn(userDetails);
+    when(this.userDetailsService.createAuthentication(userEmail)).thenReturn(authentication);
+    when(authentication.getPrincipal()).thenReturn(userDetails);
+    when(userDetails.getUser()).thenReturn(user);
+    when(user.getNickname()).thenReturn("test");
+    when(authentication.getName()).thenReturn(userEmail);
 
     // When
-    LocatTokenDto tokenDto = this.jwtProvider.create(Long.parseLong(userIdStr));
+    LocatTokenDto tokenDto = this.jwtProvider.create(userEmail);
 
     // Then
     assertThat(tokenDto).isNotNull();

--- a/src/test/java/com/locat/api/unit/security/ActiveEndUserFilterTest.java
+++ b/src/test/java/com/locat/api/unit/security/ActiveEndUserFilterTest.java
@@ -4,7 +4,7 @@ import static org.assertj.core.api.AssertionsForClassTypes.assertThatCode;
 import static org.assertj.core.api.AssertionsForClassTypes.assertThatThrownBy;
 import static org.mockito.Mockito.*;
 
-import com.locat.api.domain.user.entity.User;
+import com.locat.api.domain.user.entity.EndUser;
 import com.locat.api.global.auth.LocatUserDetails;
 import com.locat.api.global.security.filter.ActiveUserFilter;
 import jakarta.servlet.FilterChain;
@@ -23,7 +23,7 @@ import org.springframework.security.authentication.TestingAuthenticationToken;
 import org.springframework.security.core.context.SecurityContext;
 import org.springframework.security.core.context.SecurityContextHolder;
 
-class ActiveUserFilterTest {
+class ActiveEndUserFilterTest {
 
   @InjectMocks private ActiveUserFilter filter;
 
@@ -64,7 +64,7 @@ class ActiveUserFilterTest {
     FilterChain filterChain = new MockFilterChain();
 
     // When
-    User mockUser = mock(User.class);
+    EndUser mockUser = mock(EndUser.class);
     LocatUserDetails mockUserDetails = mock(LocatUserDetails.class);
     when(mockUserDetails.getUser()).thenReturn(mockUser);
     doThrow(new AccessDeniedException("Access Denied: User is not activated."))


### PR DESCRIPTION
## **해결하려는 문제가 무엇인가요?**

- 어드민 사용자 기능 추가 등이 필요한데 현재 User Entity는 소셜 로그인으로 인증하는 일반 사용자만 고려된 상태로 수정 필요

## **어떻게 해결했나요?**

- 공통 사용자 정보 담는 User Entity와, 각 구분에 따라 특화 정보 담는 EndUser / AdminUser Entity 구성
- 패키지 경로 정리 및 테스트 최신화

## **체크리스트**
- [x] 모든 commit이 push 되었나요?
- [x] merge할 branch를 확인했나요?
- [x] API 문서를 업데이트 & 문법 검사를 진행했나요?
- [x] 테스트가 전부 통과되었나요?
